### PR TITLE
Remove redundant RunRules call in PaymentsController

### DIFF
--- a/src/BinaryFlagsApi/Controllers/PaymentsController.cs
+++ b/src/BinaryFlagsApi/Controllers/PaymentsController.cs
@@ -50,9 +50,6 @@ public PaymentsController(
 
         _logger.LogInformation("Fraud check result for {PaymentType}: {Result}", paymentType, allPassed ? "Passed" : "Failed");
 
-         // Run the fraud rules using the FraudRuleEngine
-        var result = _fraudRuleEngine.RunRules(payment);
-
         if (allPassed)
         {
             _logger.LogInformation("Payment passed fraud checks.");


### PR DESCRIPTION
## Summary
- drop unused second call to `RunRules` in `PaymentsController`

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684166a9c6a0832080eb226a0c61f6ca