### PR TITLE
Fix PaymentType enum typos

### DIFF
--- a/Tests/BinaryFlagsApi.Tests/PaymentsControllerTests.cs
+++ b/Tests/BinaryFlagsApi.Tests/PaymentsControllerTests.cs
@@ -39,12 +39,12 @@ public class PaymentsControllerTests
     public void ProcessPayment_Should_Return_Ok_When_All_Rules_Pass()
     {
         // Arrange
-        var payment = new ImmediatePaymentDto { Amount = 100, PaymentType = PaymentType.ImediatePayment };
+        var payment = new ImmediatePaymentDto { Amount = 100, PaymentType = PaymentType.ImmediatePayment };
 
         var enriched = new ImmediatePaymentDto
         {
             Amount = 100,
-            PaymentType = PaymentType.ImediatePayment,
+            PaymentType = PaymentType.ImmediatePayment,
             RulesToRun = FraudRuleFlags.Rule1 | FraudRuleFlags.Rule2
         };
 
@@ -68,12 +68,12 @@ public class PaymentsControllerTests
     [Fact]
     public void ProcessPayment_Should_Return_BadRequest_When_Any_Rule_Fails()
     {
-        var payment = new FuturePaymentDto { Amount = 999, PaymentType = PaymentType.FuturePayemnt };
+        var payment = new FuturePaymentDto { Amount = 999, PaymentType = PaymentType.FuturePayment };
 
         var enriched = new FuturePaymentDto
         {
             Amount = 999,
-            PaymentType = PaymentType.FuturePayemnt,
+            PaymentType = PaymentType.FuturePayment,
             RulesToRun = FraudRuleFlags.Rule3
         };
 

--- a/Tests/Core.Tests/EnumExtensionsTests.cs
+++ b/Tests/Core.Tests/EnumExtensionsTests.cs
@@ -10,8 +10,8 @@ public class EnumExtensionsTests
 {
     [Theory]
     [InlineData(PaymentType.Unknown, "Unknown")]
-    [InlineData(PaymentType.FuturePayemnt, "Future Payment")]
-    [InlineData(PaymentType.ImediatePayment, "Immediate Payment")]
+    [InlineData(PaymentType.FuturePayment, "Future Payment")]
+    [InlineData(PaymentType.ImmediatePayment, "Immediate Payment")]
     [InlineData(PaymentType.StandingOrder, "Standing Order")]
     public void GetDisplayName_Should_Return_DisplayNameAttribute(PaymentType input, string expected)
     {

--- a/Tests/Core.Tests/PaymentDtoTypeMapTests.cs
+++ b/Tests/Core.Tests/PaymentDtoTypeMapTests.cs
@@ -8,8 +8,8 @@ namespace Core.Tests;
 public class PaymentDtoTypeMapTests
 {
     [Theory]
-    [InlineData(PaymentType.ImediatePayment, typeof(ImmediatePaymentDto))]
-    [InlineData(PaymentType.FuturePayemnt, typeof(FuturePaymentDto))]
+    [InlineData(PaymentType.ImmediatePayment, typeof(ImmediatePaymentDto))]
+    [InlineData(PaymentType.FuturePayment, typeof(FuturePaymentDto))]
     [InlineData(PaymentType.StandingOrder, typeof(StandardOrderDto))]
     public void Should_Return_Correct_Type_For_Known_Enum(PaymentType type, Type expectedDtoType)
     {

--- a/src/Core/DTO's/FuturePaymentDto.cs
+++ b/src/Core/DTO's/FuturePaymentDto.cs
@@ -4,5 +4,5 @@ namespace Core.DTOs;
 
 public class FuturePaymentDto : PaymentDto
 {
-    public FuturePaymentDto() => PaymentType = PaymentType.FuturePayemnt;
+    public FuturePaymentDto() => PaymentType = PaymentType.FuturePayment;
 }

--- a/src/Core/DTO's/ImmediatePaymentDto.cs
+++ b/src/Core/DTO's/ImmediatePaymentDto.cs
@@ -4,5 +4,5 @@ namespace Core.DTOs;
 
 public class ImmediatePaymentDto : PaymentDto
 {
-    public ImmediatePaymentDto() => PaymentType = PaymentType.ImediatePayment;
+    public ImmediatePaymentDto() => PaymentType = PaymentType.ImmediatePayment;
 }

--- a/src/Core/Enums/PaymentTypes.cs
+++ b/src/Core/Enums/PaymentTypes.cs
@@ -8,10 +8,10 @@ public enum PaymentType
     Unknown = 0,
 
     [Display(Name = "Future Payment")]
-    FuturePayemnt = 10,
+    FuturePayment = 10,
 
     [Display(Name = "Immediate Payment")]
-    ImediatePayment = 20,
+    ImmediatePayment = 20,
 
     [Display(Name = "Standing Order")]
     StandingOrder = 30

--- a/src/Core/Helpers/PaymentDtoTypeMap.cs
+++ b/src/Core/Helpers/PaymentDtoTypeMap.cs
@@ -7,8 +7,8 @@ public static class PaymentDtoTypeMap
 {
     private static readonly Dictionary<PaymentType, Type> Map = new()
     {
-        { PaymentType.ImediatePayment, typeof(ImmediatePaymentDto) },
-        { PaymentType.FuturePayemnt, typeof(FuturePaymentDto) },
+        { PaymentType.ImmediatePayment, typeof(ImmediatePaymentDto) },
+        { PaymentType.FuturePayment, typeof(FuturePaymentDto) },
         { PaymentType.StandingOrder, typeof(StandardOrderDto) }
     };
 


### PR DESCRIPTION
## Summary
- correct spelling in `PaymentType` enum
- update DTOs, helpers, and tests to use new enum names

## Testing
- `dotnet test Tests/Core.Tests/Core.Tests.csproj --verbosity normal`
- `dotnet test Tests/BinaryFlagRulesService.Tests/BinaryFlagRulesService.Tests.csproj --verbosity normal`
- `dotnet test Tests/BinaryFlagsApi.Tests/BinaryFlagsApi.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_684166c0d3b083208d786a7ba066fbe7