### PR TITLE
Rename StandardOrderDto to StandingOrderDto

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Defined in `appsettings.json`:
 "FraudRules": {
   "ImmediatePayment": "Rule1,Rule4,Rule5",
   "FuturePayment": "Rule2,Rule3,Rule6",
-  "StandardOrder": "Rule7,Rule8,Rule9,Rule10"
+  "StandingOrder": "Rule7,Rule8,Rule9,Rule10"
 }
 ```
 

--- a/Tests/BinaryFlagRulesService.Tests/PaymentDtoConverterTests.cs
+++ b/Tests/BinaryFlagRulesService.Tests/PaymentDtoConverterTests.cs
@@ -23,7 +23,7 @@ public class PaymentDtoConverterTests
     [Theory]
     [InlineData("{\"paymentType\":10,\"amount\":100}", typeof(FuturePaymentDto))]
     [InlineData("{\"paymentType\":20,\"amount\":200}", typeof(ImmediatePaymentDto))]
-    [InlineData("{\"paymentType\":30,\"amount\":300}", typeof(StandardOrderDto))]
+    [InlineData("{\"paymentType\":30,\"amount\":300}", typeof(StandingOrderDto))]
     public void Should_Deserialize_To_Correct_Derived_Type(string json, Type expectedType)
     {
         // Act

--- a/Tests/BinaryFlagRulesService.Tests/RuleFactoryTests.cs
+++ b/Tests/BinaryFlagRulesService.Tests/RuleFactoryTests.cs
@@ -24,14 +24,14 @@ public class RuleFactoryTests
         {
             ImmediatePayment = "Rule1,Rule4,Rule5",
             FuturePayment = "Rule2,Rule3,Rule6",
-            StandardOrder = "Rule7,Rule8,Rule9,Rule10"
+            StandingOrder = "Rule7,Rule8,Rule9,Rule10"
         });
     }
 
     [Theory]
     [InlineData(typeof(ImmediatePaymentDto), FraudRuleFlags.Rule1 | FraudRuleFlags.Rule4 | FraudRuleFlags.Rule5)]
     [InlineData(typeof(FuturePaymentDto), FraudRuleFlags.Rule2 | FraudRuleFlags.Rule3 | FraudRuleFlags.Rule6)]
-    [InlineData(typeof(StandardOrderDto), FraudRuleFlags.Rule7 | FraudRuleFlags.Rule8 | FraudRuleFlags.Rule9 | FraudRuleFlags.Rule10)]
+    [InlineData(typeof(StandingOrderDto), FraudRuleFlags.Rule7 | FraudRuleFlags.Rule8 | FraudRuleFlags.Rule9 | FraudRuleFlags.Rule10)]
     public void AssignRules_Should_Set_Correct_RulesToRun(Type dtoType, FraudRuleFlags expectedFlags)
     {
         // Arrange

--- a/Tests/BinaryFlagRulesService.Tests/RuleTests.cs
+++ b/Tests/BinaryFlagRulesService.Tests/RuleTests.cs
@@ -22,8 +22,8 @@ namespace BinaryFlagRulesService.Tests
                 new object[] { new Rule2(Mock.Of<ILogger<Rule2>>()), new FuturePaymentDto { Amount = 199 }, true },
 
                 // Rule3: Fail if Amount > 300
-                new object[] { new Rule3(Mock.Of<ILogger<Rule3>>()), new StandardOrderDto { Amount = 350 }, false },
-                new object[] { new Rule3(Mock.Of<ILogger<Rule3>>()), new StandardOrderDto { Amount = 250 }, true },
+                new object[] { new Rule3(Mock.Of<ILogger<Rule3>>()), new StandingOrderDto { Amount = 350 }, false },
+                new object[] { new Rule3(Mock.Of<ILogger<Rule3>>()), new StandingOrderDto { Amount = 250 }, true },
 
                 // Rule4: Fail if Amount > 400
                 new object[] { new Rule4(Mock.Of<ILogger<Rule4>>()), new ImmediatePaymentDto { Amount = 450 }, false },
@@ -38,8 +38,8 @@ namespace BinaryFlagRulesService.Tests
                 new object[] { new Rule6(Mock.Of<ILogger<Rule6>>()), new ImmediatePaymentDto { Amount = 550 }, true },
 
                 // Rule7: Fail if Amount > 700
-                new object[] { new Rule7(Mock.Of<ILogger<Rule7>>()), new StandardOrderDto { Amount = 750 }, false },
-                new object[] { new Rule7(Mock.Of<ILogger<Rule7>>()), new StandardOrderDto { Amount = 650 }, true },
+                new object[] { new Rule7(Mock.Of<ILogger<Rule7>>()), new StandingOrderDto { Amount = 750 }, false },
+                new object[] { new Rule7(Mock.Of<ILogger<Rule7>>()), new StandingOrderDto { Amount = 650 }, true },
 
                 // Rule8: Fail if Amount > 800
                 new object[] { new Rule8(Mock.Of<ILogger<Rule8>>()), new ImmediatePaymentDto { Amount = 850 }, false },

--- a/Tests/Core.Tests/PaymentDtoTypeMapTests.cs
+++ b/Tests/Core.Tests/PaymentDtoTypeMapTests.cs
@@ -10,7 +10,7 @@ public class PaymentDtoTypeMapTests
     [Theory]
     [InlineData(PaymentType.ImediatePayment, typeof(ImmediatePaymentDto))]
     [InlineData(PaymentType.FuturePayemnt, typeof(FuturePaymentDto))]
-    [InlineData(PaymentType.StandingOrder, typeof(StandardOrderDto))]
+    [InlineData(PaymentType.StandingOrder, typeof(StandingOrderDto))]
     public void Should_Return_Correct_Type_For_Known_Enum(PaymentType type, Type expectedDtoType)
     {
         // Act

--- a/src/BinaryFlagRulesService/Configs/FraudRulesConfig.cs
+++ b/src/BinaryFlagRulesService/Configs/FraudRulesConfig.cs
@@ -9,7 +9,7 @@ public class FraudRulesConfig
 {
     public string ImmediatePayment { get; set; }
     public string FuturePayment { get; set; }
-    public string StandardOrder { get; set; }
+    public string StandingOrder { get; set; }
 
     public Dictionary<string, FraudRuleFlags> ToFlagMap()
     {
@@ -17,7 +17,7 @@ public class FraudRulesConfig
         {
             { nameof(ImmediatePaymentDto), ParseFlags(ImmediatePayment) },
             { nameof(FuturePaymentDto), ParseFlags(FuturePayment) },
-            { nameof(StandardOrderDto), ParseFlags(StandardOrder) }
+            { nameof(StandingOrderDto), ParseFlags(StandingOrder) }
         };
     }
 

--- a/src/BinaryFlagsApi/appsettings.json
+++ b/src/BinaryFlagsApi/appsettings.json
@@ -10,7 +10,7 @@
   "FraudRules": {
     "ImmediatePayment": "Rule1,Rule4,Rule5",
     "FuturePayment": "Rule2,Rule3,Rule6",
-    "StandardOrder": "Rule3,Rule7,Rule8,Rule9,Rule10"
+    "StandingOrder": "Rule3,Rule7,Rule8,Rule9,Rule10"
   },
   "Kestrel": {
     "Endpoints": {

--- a/src/Core/DTO's/StandardOrderDto.cs
+++ b/src/Core/DTO's/StandardOrderDto.cs
@@ -1,8 +1,0 @@
-using Core.Enums;
-
-namespace Core.DTOs;
-
-public class StandardOrderDto : PaymentDto
-{
-    public StandardOrderDto() => PaymentType = PaymentType.StandingOrder;
-}

--- a/src/Core/DTO's/StandingOrderDto.cs
+++ b/src/Core/DTO's/StandingOrderDto.cs
@@ -1,0 +1,8 @@
+using Core.Enums;
+
+namespace Core.DTOs;
+
+public class StandingOrderDto : PaymentDto
+{
+    public StandingOrderDto() => PaymentType = PaymentType.StandingOrder;
+}

--- a/src/Core/Helpers/PaymentDtoTypeMap.cs
+++ b/src/Core/Helpers/PaymentDtoTypeMap.cs
@@ -9,7 +9,7 @@ public static class PaymentDtoTypeMap
     {
         { PaymentType.ImediatePayment, typeof(ImmediatePaymentDto) },
         { PaymentType.FuturePayemnt, typeof(FuturePaymentDto) },
-        { PaymentType.StandingOrder, typeof(StandardOrderDto) }
+        { PaymentType.StandingOrder, typeof(StandingOrderDto) }
     };
 
     public static Type? GetType(PaymentType paymentType)


### PR DESCRIPTION
## Summary
- rename `StandardOrderDto` class and file to `StandingOrderDto`
- rename `FraudRulesConfig.StandardOrder` property to `StandingOrder`
- update configuration, mappings and tests for new name

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684166dc36cc8320bc2defa785c9da30